### PR TITLE
Client posh

### DIFF
--- a/letsencrypt-win/LetsEncrypt.ACME.POSH/ACMEPowerShell-IIS/ACMEPowerShell-IIS.psm1
+++ b/letsencrypt-win/LetsEncrypt.ACME.POSH/ACMEPowerShell-IIS/ACMEPowerShell-IIS.psm1
@@ -7,7 +7,7 @@ Configure/install certs
 
 Install-ACMECertificateToIIS -Ref <cert-ref>
 	-ComputerName <target-server> - optional (defaults to local)
-	-Website <website-name> - required
+	-Website <website-name> - optional (defaults to 'Default Web Site')
 	-HostHeader <hostheader-name> - optional (defaults to none)
 	-IPAddress <ip-address> - optional (defaults to all)
 	-Port <port-num> - optional (defaults to 443)
@@ -18,24 +18,14 @@ function Install-CertificateToIIS {
 	param(
 		[Parameter(Mandatory=$true)]
 		[string]$Certificate,
-		[Parameter(Mandatory=$true)]
-		[string]$WebSite,
+		[string]$WebSite = "Default Web Site",
 		[string]$IPAddress,
 		[int]$Port,
 		[string]$SNIHostname,
 		[switch]$SNIRequired,
 		[switch]$Replace,
 
-		[System.Management.Automation.Runspaces.PSSession]$RemoteSession,
-
-		## AWS POSH Base Params
-		[object]$Region,
-		[string]$AccessKey,
-		[string]$SecretKey,
-		[string]$SessionToken,
-		[string]$ProfileName,
-		[string]$ProfilesLocation,
-		[Amazon.Runtime.AWSCredentials]$Credentials
+		[System.Management.Automation.Runspaces.PSSession]$RemoteSession
 	)
 
 	## TODO:  We'll need to either "assume" that the user has
@@ -47,16 +37,16 @@ function Install-CertificateToIIS {
 	if ($ci.IssuerSerialNumber) {
 		$ic = Get-ACMEIssuerCertificate -SerialNumber $ci.IssuerSerialNumber
 		if ($ic) {
-			if (-not $ic.CrtPemFile -or -not (Test-Path -PathType Leaf $ic.CrtPemFile)) {
-				throw "Unable to resolve Issuer Certificate PEM file"
+			if (-not $ic.CrtPemFile) {
+				throw "Unable to resolve Issuer Certificate PEM file $($ci.IssuerSerialNumber)"
 			}
 		}
 	}
 
-	if (-not $ci.KeyPemFile -or -not (Test-Path -PathType Leaf $ci.KeyPemFile)) {
+	if (-not $ci.KeyPemFile) {
 		throw "Unable to resolve Private Key PEM file"
 	}
-	if (-not $ci.CrtPemFile -or -not (Test-Path -PathType Leaf $ci.CrtPemFile)) {
+	if (-not $ci.CrtPemFile) {
 		throw "Unable to resolve Certificate PEM file"
 	}
 

--- a/letsencrypt-win/LetsEncrypt.ACME.POSH/EditProviderConfig.cs
+++ b/letsencrypt-win/LetsEncrypt.ACME.POSH/EditProviderConfig.cs
@@ -24,6 +24,10 @@ namespace LetsEncrypt.ACME.POSH
         { get; set; }
 
         [Parameter]
+        public string EditWith
+        { get; set; }
+
+        [Parameter]
         public string VaultProfile
         { get; set; }
 
@@ -58,6 +62,13 @@ namespace LetsEncrypt.ACME.POSH
                         {
                             s.CopyTo(fs);
                         }
+                    }
+                    NewProviderConfig.EditFile(temp, EditWith);
+
+                    using (Stream fs = new FileStream(temp, FileMode.Open),
+                            assetStream = vp.SaveAsset(pcAsset))
+                    {
+                        fs.CopyTo(assetStream);
                     }
                 }
             }

--- a/letsencrypt-win/LetsEncrypt.ACME.POSH/EditProviderConfig.cs
+++ b/letsencrypt-win/LetsEncrypt.ACME.POSH/EditProviderConfig.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using LetsEncrypt.ACME.POSH.Vault;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -48,7 +49,16 @@ namespace LetsEncrypt.ACME.POSH
                         throw new Exception("Unable to find Provider Config for the given reference");
                     var pcFilePath = Path.GetFullPath($"{pc.Id}.json");
 
-                    WriteObject(pcFilePath);
+                    // Copy out the asset to a temp file for editing
+                    var pcAsset = vp.GetAsset(VaultAssetType.ProviderConfigInfo, $"{pc.Id}.json");
+                    var temp = Path.GetTempFileName();
+                    using (var s = vp.LoadAsset(pcAsset))
+                    {
+                        using (var fs = new FileStream(temp, FileMode.Create))
+                        {
+                            s.CopyTo(fs);
+                        }
+                    }
                 }
             }
         }

--- a/letsencrypt-win/LetsEncrypt.ACME.POSH/LetsEncrypt.ACME.POSH.csproj
+++ b/letsencrypt-win/LetsEncrypt.ACME.POSH/LetsEncrypt.ACME.POSH.csproj
@@ -138,4 +138,12 @@
   <Target Name="AfterBuild">
   </Target>
   -->
+  <!-- Normally this is something defined in the user-specific MSBuild configuration by
+       Visual Studio, but we put it in the durable config that's shared by all developers. -->
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'">
+    <StartAction>Program</StartAction>
+    <StartProgram>C:\Windows\syswow64\WindowsPowerShell\v1.0\powershell.exe</StartProgram>
+    <StartArguments>-ExecutionPolicy RemoteSigned -NoExit -Command "ipmo .\$(Configuration)\ACMEPowerShell; if (-not (Test-Path TestVault)) { mkdir TestVault }; cd .\TestVault"</StartArguments>
+    <StartWorkingDirectory>..\..</StartWorkingDirectory>
+  </PropertyGroup>
 </Project>

--- a/letsencrypt-win/LetsEncrypt.ACME.POSH/LetsEncrypt.ACME.POSH.csproj
+++ b/letsencrypt-win/LetsEncrypt.ACME.POSH/LetsEncrypt.ACME.POSH.csproj
@@ -104,6 +104,7 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
+    <EmbeddedResource Include="ProviderConfigSamples\webServerInfo.json.sample-ManualWebServerProvider" />
     <None Include="ACMEPowerShell-AWS\ACMEPowerShell-AWS.psm1">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
@@ -123,7 +124,7 @@
     <EmbeddedResource Include="ProviderConfigSamples\dnsInfo.json.sample-AwsRoute53DnsProvider" />
     <EmbeddedResource Include="ProviderConfigSamples\dnsInfo.json.sample-ManualDnsProvider" />
     <EmbeddedResource Include="ProviderConfigSamples\webServerInfo.json.sample-AwsS3WebServerProvider" />
-    <EmbeddedResource Include="ProviderConfigSamples\webServerInfo.json.sample-ManualWebServerProvider" />
+    <EmbeddedResource Include="ProviderConfigSamples\webServerInfo.json.sample-IisSitePathWebServerProvider" />
   </ItemGroup>
   <ItemGroup>
     <Content Include="libeay32.dll" />

--- a/letsencrypt-win/LetsEncrypt.ACME.POSH/NewCertificate.cs
+++ b/letsencrypt-win/LetsEncrypt.ACME.POSH/NewCertificate.cs
@@ -87,11 +87,10 @@ namespace LetsEncrypt.ACME.POSH
                     };
 
                     ci.GenerateDetailsFile = $"{ci.Id}-gen.json";
-
-                    using (var fs = new FileStream(Path.GetFullPath(ci.GenerateDetailsFile),
-                            FileMode.CreateNew))
+                    var asset = vp.CreateAsset(VaultAssetType.CsrDetails, ci.GenerateDetailsFile);
+                    using (var s = vp.SaveAsset(asset))
                     {
-                        JsonHelper.Save(fs, csrDetails);
+                        JsonHelper.Save(s, csrDetails);
                     }
                 }
                 else
@@ -104,8 +103,19 @@ namespace LetsEncrypt.ACME.POSH
                     var keyPemFile = $"{ci.Id}-key.pem";
                     var csrPemFile = $"{ci.Id}-csr.pem";
 
-                    File.Copy(KeyPemFile, keyPemFile);
-                    File.Copy(CsrPemFile, csrPemFile);
+                    var keyAsset = vp.CreateAsset(VaultAssetType.KeyPem, keyPemFile, true);
+                    var csrAsset = vp.CreateAsset(VaultAssetType.CsrPem, csrPemFile);
+
+                    using (Stream fs = new FileStream(KeyPemFile, FileMode.Open),
+                            s = vp.SaveAsset(keyAsset))
+                    {
+                        fs.CopyTo(s);
+                    }
+                    using (Stream fs = new FileStream(KeyPemFile, FileMode.Open),
+                            s = vp.SaveAsset(csrAsset))
+                    {
+                        fs.CopyTo(s);
+                    }
 
                     ci.KeyPemFile = keyPemFile;
                     ci.CsrPemFile = csrPemFile;

--- a/letsencrypt-win/LetsEncrypt.ACME.POSH/NewProviderConfig.cs
+++ b/letsencrypt-win/LetsEncrypt.ACME.POSH/NewProviderConfig.cs
@@ -40,6 +40,11 @@ namespace LetsEncrypt.ACME.POSH
         public string WebServerProvider
         { get; set; }
 
+
+        [Parameter]
+        public string EditWith
+        { get; set; }
+
         [Parameter]
         public string VaultProfile
         { get; set; }
@@ -56,7 +61,7 @@ namespace LetsEncrypt.ACME.POSH
                 WebServerProvider = WebServerProvider,
             };
 
-            var pcFilePath = Path.GetFullPath($"{pc.Id}.json");
+            //!!!var pcFilePath = Path.GetFullPath($"{pc.Id}.json");
 
             using (var vp = InitializeVault.GetVaultProvider(VaultProfile))
             {
@@ -90,6 +95,7 @@ namespace LetsEncrypt.ACME.POSH
                 {
                     s.CopyTo(fs);
                 }
+                EditFile(temp, EditWith);
 
                 var pcAsset = vp.CreateAsset(VaultAssetType.ProviderConfigInfo, $"{pc.Id}.json");
                 using (Stream fs = new FileStream(temp, FileMode.Open),
@@ -108,7 +114,22 @@ namespace LetsEncrypt.ACME.POSH
                 s.Dispose();
             }
 
-            WriteObject(pcFilePath);
+            //!!!WriteObject(pcFilePath);
+        }
+
+        public static void EditFile(string path, string editWith = null)
+        {
+            // TODO: For now we hard code the path to the default editor (Notepad)
+            //       but we should compute this from the registry:
+            //           HKEY_CLASSES_ROOT\txtfile\shell\open\command
+            if (editWith == null)
+                editWith = @"%SystemRoot%\system32\NOTEPAD.EXE";
+
+            // Expand any potential envvars
+            editWith = Environment.ExpandEnvironmentVariables(editWith);
+
+            var p = Process.Start(editWith, path);
+            p.WaitForExit();
         }
     }
 }

--- a/letsencrypt-win/LetsEncrypt.ACME.POSH/NewProviderConfig.cs
+++ b/letsencrypt-win/LetsEncrypt.ACME.POSH/NewProviderConfig.cs
@@ -36,7 +36,7 @@ namespace LetsEncrypt.ACME.POSH
         { get; set; }
 
         [Parameter(ParameterSetName = PSET_HTTP, Mandatory = true)]
-        [ValidateSet("Manual", "AwsS3")]
+        [ValidateSet("Manual", "AwsS3", "IisSitePath")]
         public string WebServerProvider
         { get; set; }
 

--- a/letsencrypt-win/LetsEncrypt.ACME.POSH/ProviderConfigSamples/dnsInfo.json.sample-AwsRoute53DnsProvider
+++ b/letsencrypt-win/LetsEncrypt.ACME.POSH/ProviderConfigSamples/dnsInfo.json.sample-AwsRoute53DnsProvider
@@ -1,10 +1,10 @@
 ﻿{
-    "DefaultDomain": "sample.com",
-    "Provider": {
-        "$type": "LetsEncrypt.ACME.DNS.AwsRoute53DnsProvider, LetsEncrypt.ACME",
-        "HostedZoneId": "Route53-Hosted-Zone-ID",
-        "AccessKeyId": "IAM-Account-AccessKey",
-        "SecretAccessKey": "IAM-Account-SecretKey",
-        "Region": "us-east-1"
-    }
+  "DefaultDomain": "sample.com",
+  "Provider": {
+    "$type": "LetsEncrypt.ACME.DNS.AwsRoute53DnsProvider, LetsEncrypt.ACME",
+    "HostedZoneId": "Route53-Hosted-Zone-ID",
+    "AccessKeyId": "IAM-Account-AccessKey",
+    "SecretAccessKey": "IAM-Account-SecretKey",
+    "Region": "us-east-1"
+  }
 }

--- a/letsencrypt-win/LetsEncrypt.ACME.POSH/ProviderConfigSamples/dnsInfo.json.sample-ManualDnsProvider
+++ b/letsencrypt-win/LetsEncrypt.ACME.POSH/ProviderConfigSamples/dnsInfo.json.sample-ManualDnsProvider
@@ -1,6 +1,5 @@
 ﻿{
-    "DefaultDomain": "sample.com",
-    "Provider": {
-        "$type": "LetsEncrypt.ACME.DNS.ManualDnsProvider, LetsEncrypt.ACME",
-    }
+  "Provider": {
+    "$type": "LetsEncrypt.ACME.DNS.ManualDnsProvider, LetsEncrypt.ACME",
+  }
 }

--- a/letsencrypt-win/LetsEncrypt.ACME.POSH/ProviderConfigSamples/webServerInfo.json.sample-AwsS3WebServerProvider
+++ b/letsencrypt-win/LetsEncrypt.ACME.POSH/ProviderConfigSamples/webServerInfo.json.sample-AwsS3WebServerProvider
@@ -1,17 +1,17 @@
 ﻿{
-    "Provider": {
-        "$type": "LetsEncrypt.ACME.WebServer.AwsS3WebServerProvider, LetsEncrypt.ACME",
-        "BucketName": "acmetesting.sample.com",
-        "AccessKeyId": "IAM-Account-AccessKey",
-        "SecretAccessKey": "IAM-Account-SecretKey",
-        "Region": "us-east-1",
-        "DnsProvider": {
-            "$type": "LetsEncrypt.ACME.DNS.AwsRoute53DnsProvider, LetsEncrypt.ACME",
-            "HostedZoneId": "Route53-Hosted-Zone-ID",
-            "AccessKeyId": "IAM-Account-AccessKey",
-            "SecretAccessKey": "IAM-Account-SecretKey",
-            "Region": "us-east-1"
-        },
-        "DnsCnameTarget":  "star.acmetesting.sample.com"
-    }
+  "Provider": {
+    "$type": "LetsEncrypt.ACME.WebServer.AwsS3WebServerProvider, LetsEncrypt.ACME",
+    "BucketName": "acmetesting.sample.com",
+    "AccessKeyId": "IAM-Account-AccessKey",
+    "SecretAccessKey": "IAM-Account-SecretKey",
+    "Region": "us-east-1",
+    "DnsProvider": {
+      "$type": "LetsEncrypt.ACME.DNS.AwsRoute53DnsProvider, LetsEncrypt.ACME",
+      "HostedZoneId": "Route53-Hosted-Zone-ID",
+      "AccessKeyId": "IAM-Account-AccessKey",
+      "SecretAccessKey": "IAM-Account-SecretKey",
+      "Region": "us-east-1"
+    },
+    "DnsCnameTarget": "star.acmetesting.sample.com"
+  }
 }

--- a/letsencrypt-win/LetsEncrypt.ACME.POSH/ProviderConfigSamples/webServerInfo.json.sample-IisSitePathWebServerProvider
+++ b/letsencrypt-win/LetsEncrypt.ACME.POSH/ProviderConfigSamples/webServerInfo.json.sample-IisSitePathWebServerProvider
@@ -1,0 +1,9 @@
+﻿{
+  "Provider": {
+    "$type": "LetsEncrypt.ACME.WebServer.IisSitePathProvider, LetsEncrypt.ACME",
+
+    // WebSiteRoot is the required path to the root directory of the target
+    // IIS Web site where the content of the challenge response will be saved.
+    "WebSiteRoot": ".\\path\\to\\webSite"
+  }
+}

--- a/letsencrypt-win/LetsEncrypt.ACME.POSH/ProviderConfigSamples/webServerInfo.json.sample-ManualWebServerProvider
+++ b/letsencrypt-win/LetsEncrypt.ACME.POSH/ProviderConfigSamples/webServerInfo.json.sample-ManualWebServerProvider
@@ -1,6 +1,10 @@
 ﻿{
-    "Provider": {
-        "$type": "LetsEncrypt.ACME.WebServer.ManualWebServerProvider, LetsEncrypt.ACME",
-        "FilePath": ".\\path\\to\\web-content"
-    }
+  "Provider": {
+    "$type": "LetsEncrypt.ACME.WebServer.ManualWebServerProvider, LetsEncrypt.ACME",
+
+    // FilePath is an optional path to a file where the content of
+    // the challenge response will be saved.  If unspecified, a
+    // temporary file will be created and returned in the output.
+    "FilePath": ".\\path\\to\\web-content-file"
+  }
 }

--- a/letsencrypt-win/LetsEncrypt.ACME.POSH/SubmitCertificate.cs
+++ b/letsencrypt-win/LetsEncrypt.ACME.POSH/SubmitCertificate.cs
@@ -118,6 +118,13 @@ namespace LetsEncrypt.ACME.POSH
                         CsrHelper.Crt.ConvertDerToPem(source, target);
                         ci.CrtPemFile = crtPemFile;
                     }
+
+                    var crt = new X509Certificate2(crtDerFile);
+
+                    ci.SerialNumber = crt.SerialNumber;
+                    ci.Thumbprint = crt.Thumbprint;
+                    ci.SignatureAlgorithm = crt.SignatureAlgorithm?.FriendlyName;
+                    ci.Signature = crt.GetCertHashString();
                 }
 
                 vp.SaveVault(v);

--- a/letsencrypt-win/LetsEncrypt.ACME.POSH/SubmitChallenge.cs
+++ b/letsencrypt-win/LetsEncrypt.ACME.POSH/SubmitChallenge.cs
@@ -8,7 +8,7 @@ using System.Threading.Tasks;
 
 namespace LetsEncrypt.ACME.POSH
 {
-    [Cmdlet(VerbsLifecycle.Submit, "Challenges")]
+    [Cmdlet(VerbsLifecycle.Submit, "Challenge")]
     public class SubmitChallenge : Cmdlet
     {
         [Parameter(Mandatory = true)]

--- a/letsencrypt-win/LetsEncrypt.ACME.POSH/Vault/IVaultProvider.cs
+++ b/letsencrypt-win/LetsEncrypt.ACME.POSH/Vault/IVaultProvider.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.IO;
 
 namespace LetsEncrypt.ACME.POSH.Vault
 {
@@ -22,5 +24,78 @@ namespace LetsEncrypt.ACME.POSH.Vault
         VaultConfig LoadVault(bool required = true);
 
         void SaveVault(VaultConfig vault);
+
+        IEnumerable<VaultAsset> ListAssets(string nameRegex = null, params VaultAssetType[] type);
+
+        VaultAsset CreateAsset(VaultAssetType type, string name, bool isSensitive = false);
+
+        VaultAsset GetAsset(VaultAssetType type, string name);
+
+        Stream SaveAsset(VaultAsset asset);
+
+        Stream LoadAsset(VaultAsset asset);
+    }
+
+    public enum VaultAssetType
+    {
+        Other = 0,
+
+        /// <summary>
+        /// A DnsInfo or WebServerInfo file to instantiate and
+        /// configure a Provider for handling a Challenge.
+        /// </summary>
+        ProviderConfigInfo,
+
+        /// <summary>
+        /// Stores intermediate details when generating a CSR.
+        /// </summary>
+        CsrDetails,
+
+        /// <summary>
+        /// Imported or generated private key PEM file.
+        /// </summary>
+        KeyPem,
+        /// <summary>
+        /// Imported or generated CSR PEM file.
+        /// </summary>
+        CsrPem,
+
+        /// <summary>
+        /// Generated private key full details.
+        /// </summary>
+        KeyGen,
+        /// <summary>
+        /// Generated CSR full details.
+        /// </summary>
+        CsrGen,
+
+        /// <summary>
+        /// DER-encoded form of CSR (used directly in the ACME protocol).
+        /// </summary>
+        CsrDer,
+
+        /// <summary>
+        /// DER-encoded form of the issued cert (returned from CA as per ACME spec).
+        /// </summary>
+        CrtDer,
+        /// <summary>
+        /// PEM-encoded form of the issued cert.
+        /// </summary>
+        CrtPem,
+
+        IssuerDer,
+        IssuerPem,
+    }
+
+    public class VaultAsset
+    {
+        public virtual string Name
+        { get; protected set; }
+
+        public virtual VaultAssetType Type
+        { get; protected set; }
+
+        public virtual bool IsSensitive
+        { get; protected set; }
     }
 }

--- a/letsencrypt-win/LetsEncrypt.ACME/AcmeClient.cs
+++ b/letsencrypt-win/LetsEncrypt.ACME/AcmeClient.cs
@@ -415,14 +415,15 @@ namespace LetsEncrypt.ACME
             return c;
         }
 
-        public AuthorizeChallenge SubmitAuthorizeChallengeAnswer(AuthorizationState authzState, string type, bool useRootUrl = false)
+        public AuthorizeChallenge SubmitAuthorizeChallengeAnswer(AuthorizationState authzState,
+                string type, bool useRootUrl = false)
         {
             AssertInit();
             AssertRegistration();
 
             var c = authzState.Challenges.FirstOrDefault(x => x.Type == type);
             if (c == null)
-                throw new ArgumentOutOfRangeException("no challenge found matching requested type");
+                throw new ArgumentException("no challenge found matching requested type");
 
             if (c.ChallengeAnswer.Key == null || c.ChallengeAnswer.Value == null || c.ChallengeAnswerMessage == null)
                 throw new InvalidOperationException("challenge answer has not been generated");

--- a/letsencrypt-win/LetsEncrypt.ACME/DNS/IDnsProvider.cs
+++ b/letsencrypt-win/LetsEncrypt.ACME/DNS/IDnsProvider.cs
@@ -7,7 +7,7 @@ using System.Threading.Tasks;
 namespace LetsEncrypt.ACME.DNS
 {
 
-    public interface IDnsProvider
+    public interface IDnsProvider : IChallengeHandlingProvider
     {
         void EditTxtRecord(string dnsName, IEnumerable<string> dnsValues);
 

--- a/letsencrypt-win/LetsEncrypt.ACME/IChallengeHandlingProvider.cs
+++ b/letsencrypt-win/LetsEncrypt.ACME/IChallengeHandlingProvider.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace LetsEncrypt.ACME
+{
+    /// <summary>
+    /// A tagging interface to identify all challenge type-specific handling providers.
+    /// </summary>
+    public interface IChallengeHandlingProvider
+    { }
+}

--- a/letsencrypt-win/LetsEncrypt.ACME/LetsEncrypt.ACME.csproj
+++ b/letsencrypt-win/LetsEncrypt.ACME/LetsEncrypt.ACME.csproj
@@ -114,6 +114,7 @@
     <Compile Include="WebServer\AwsS3WebServerProvider.cs" />
     <Compile Include="WebServer\IWebServerProvider.cs" />
     <Compile Include="WebServer\ManualWebServerProvider.cs" />
+    <Compile Include="WebServer\IisSitePathProvider.cs" />
     <Compile Include="WebServer\WebServerInfo.cs" />
   </ItemGroup>
   <ItemGroup>
@@ -126,6 +127,7 @@
     <Content Include="ssleay32.dll">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
+    <EmbeddedResource Include="WebServer\IisSitePathProvider-WebConfig" />
   </ItemGroup>
   <ItemGroup />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/letsencrypt-win/LetsEncrypt.ACME/LetsEncrypt.ACME.csproj
+++ b/letsencrypt-win/LetsEncrypt.ACME/LetsEncrypt.ACME.csproj
@@ -86,6 +86,7 @@
     <Compile Include="DNS\ManualDnsProvider.cs" />
     <Compile Include="HTTP\Link.cs" />
     <Compile Include="HTTP\LinkCollection.cs" />
+    <Compile Include="IChallengeHandlingProvider.cs" />
     <Compile Include="JOSE\ISigner.cs" />
     <Compile Include="JOSE\JwsHeaders.cs" />
     <Compile Include="JOSE\JwsHelper.cs" />

--- a/letsencrypt-win/LetsEncrypt.ACME/WebServer/IWebServerProvider.cs
+++ b/letsencrypt-win/LetsEncrypt.ACME/WebServer/IWebServerProvider.cs
@@ -7,7 +7,7 @@ using System.Threading.Tasks;
 
 namespace LetsEncrypt.ACME.WebServer
 {
-    public interface IWebServerProvider
+    public interface IWebServerProvider : IChallengeHandlingProvider
     {
         void UploadFile(Uri fileUrl, Stream s);
     }

--- a/letsencrypt-win/LetsEncrypt.ACME/WebServer/IisSitePathProvider-WebConfig
+++ b/letsencrypt-win/LetsEncrypt.ACME/WebServer/IisSitePathProvider-WebConfig
@@ -1,0 +1,8 @@
+﻿<?xml version="1.0" encoding="UTF-8"?>
+ <configuration>
+     <system.webServer>
+         <staticContent>
+             <mimeMap fileExtension=".*" mimeType="text/json" />
+         </staticContent>
+     </system.webServer>
+ </configuration>

--- a/letsencrypt-win/LetsEncrypt.ACME/WebServer/IisSitePathProvider.cs
+++ b/letsencrypt-win/LetsEncrypt.ACME/WebServer/IisSitePathProvider.cs
@@ -1,0 +1,90 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Security.Principal;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace LetsEncrypt.ACME.WebServer
+{
+    /// <summary>
+    /// Implements a file-based <see cref="IWebServerProvider">Web Server Provider</see>
+    /// that constructs the necessary directory and file path under a given Web site
+    /// root path. 
+    /// </summary>
+    /// <remarks>
+    /// This provider should be configured with the path to the root folder of the
+    /// target site that is being used to validate a DNS Identifier.  Under this root
+    /// path, the provider will construct the necessary intermediate folders, and
+    /// challenge response file containing the content that is provided.
+    /// <para>
+    /// Additionally, if the file path references a file without an extension, it will
+    /// generate a local <code>web.config</code> file in the same folder as the target
+    /// file which will enable an IIS site configured to operate under an integrated
+    /// pipeline mode to successfully serve up the file as a JSON mime-type.  By default
+    /// IIS will not serve up a file without an extension in this scenario.
+    /// </para>
+    /// </remarks>
+    public class IisSitePathProvider : IWebServerProvider
+    {
+        /// <summary>
+        /// Path to the root directory of the target Web site.
+        /// </summary>
+        public string WebSiteRoot
+        { get; set; }
+
+        public void UploadFile(Uri fileUrl, Stream s)
+        {
+            if (string.IsNullOrWhiteSpace(WebSiteRoot))
+                throw new InvalidOperationException("Web site root is unspecified or invalid");
+            if (!Directory.Exists(WebSiteRoot))
+                throw new DirectoryNotFoundException("Web site root is missing");
+
+            var filePath = fileUrl.AbsolutePath;
+            if (filePath.StartsWith("/"))
+                filePath = filePath.Substring(1);
+            filePath = filePath.Replace('/', '\\');
+
+            var fullPath = Path.Combine(WebSiteRoot, filePath);
+            var dirPath = Path.GetDirectoryName(fullPath);
+            var fileName = Path.GetFileName(fullPath);
+
+            // Check if user is running with elevated privs and warn if not
+            if (!IsAdministrator())
+            {
+                Console.Error.WriteLine("WARNING:  You are not running with elelvated privileges.");
+                Console.Error.WriteLine("          Write access may be denied to the destination.");
+            }
+
+            Directory.CreateDirectory(dirPath);
+            using (var fs = new FileStream(fullPath, FileMode.Create))
+            {
+                s.CopyTo(fs);
+            }
+
+            // If the target file path is a file without an extension,
+            // we need to tell IIS that it's OK to serve it up, and to
+            // associate a default MIME type (text/json)
+            if (string.IsNullOrEmpty(Path.GetExtension(filePath)))
+            {
+                var t = typeof(IisSitePathProvider);
+                var wcPath = Path.Combine(dirPath, "web.config");
+                using (Stream rs = t.Assembly.GetManifestResourceStream(
+                        $"{t.Namespace}.IisSitePathProvider-WebConfig"),
+                        fs = new FileStream(wcPath, FileMode.Create))
+                {
+                    rs.CopyTo(fs);
+                }
+            }
+        }
+
+        public static bool IsAdministrator()
+        {
+            var winId = WindowsIdentity.GetCurrent();
+            var principal = new WindowsPrincipal(winId);
+
+            return principal.IsInRole(WindowsBuiltInRole.Administrator);
+        }
+    }
+}

--- a/letsencrypt-win/LetsEncrypt.ACME/WebServer/ManualWebServerProvider.cs
+++ b/letsencrypt-win/LetsEncrypt.ACME/WebServer/ManualWebServerProvider.cs
@@ -26,6 +26,10 @@ namespace LetsEncrypt.ACME.WebServer
                     path = string.Format("{0}.{1}", FilePath, ++index);
             }
 
+            var dir = Path.GetDirectoryName(path);
+            if (!Directory.Exists(dir))
+                throw new DirectoryNotFoundException("Missing folder in requested file path");
+            
             using (var fs = new FileStream(path, FileMode.CreateNew))
             {
                 s.CopyTo(fs);


### PR DESCRIPTION
* This includes a couple breaking changes:
  * the `Submit-ACMEChallenge` cmdlet has been properly renamed (dropped the last 's').
  * with the new Vault assets enhancements, the location of almost all the additional files are now relocated for the File-base Vault Provider.  So accessing files in an existing Vault won't work properly.  The main Vault meta data file should still be in tact, but many of the child assets will need to be regenerated/revalidated/resubmitted.  (Pby best to just recreate a new Vault (it's free!).)
* The Vault assets should not (hopefully) address all the file path issues related to the distinction between the PowerShell file system provider's notion of current path, and the process current path (they should effectively be the same).
